### PR TITLE
Allow to create admin users

### DIFF
--- a/jobs/influxdb/templates/bin/influxdb_setup.erb
+++ b/jobs/influxdb/templates/bin/influxdb_setup.erb
@@ -51,10 +51,10 @@ userpwd = {}
 useradmin = {}
 users.each do |user|
   raise "Unknown privilege #{user['privilege']}" unless ['admin','readwrite','write','read'].include? user['privilege']
-  raise "Admin privileges for user #{user['name']} can't be applied to a single database" if user['privilege'] == 'admin' && user['database'] != ''
+  raise "Admin privileges for user #{user['name']} can't be applied to a single database" if user['privilege'] == 'admin' && !user['database'].nil?
   raise "User #{user['name']} can't be both admin and non-admin" if useradmin.key? user['name'] && useradmin[user['name']] != (user['privilege'] == 'admin')
   useradmin[user['name']] = (user['privilege'] == 'admin')
-  raise "Database name (#{user['database']}) is not listed in influxdb.databases" unless dbs.include? user['database']
+  raise "Database name (#{user['database']}) is not listed in influxdb.databases" unless dbs.include? user['database'] || user['database'].nil?
   raise "User name (#{user['name']} should match #{username_regex.inspect}" unless user['name'].match(username_regex)
   raise "User name #{admin_username} is reserved" if user['name'] == admin_username
   raise "Password for user #{user['name']} should match #{password_regex.inspect}" unless user['password'].match(password_regex)

--- a/jobs/influxdb/templates/bin/influxdb_setup.erb
+++ b/jobs/influxdb/templates/bin/influxdb_setup.erb
@@ -51,10 +51,10 @@ userpwd = {}
 useradmin = {}
 users.each do |user|
   raise "Unknown privilege #{user['privilege']}" unless ['admin','readwrite','write','read'].include? user['privilege']
-  raise "Admin privileges for user #{user['name']} can't be applied to a single database" if user['privilege'] == 'admin' && !user['database'].nil?
-  raise "User #{user['name']} can't be both admin and non-admin" if useradmin.key? user['name'] && useradmin[user['name']] != (user['privilege'] == 'admin')
+  raise "Admin privileges for user #{user['name']} can't be applied to a single database" if (user['privilege'] == 'admin') && user['database'].to_s != ''
+  raise "User #{user['name']} can't be both admin and non-admin" if useradmin.key?(user['name']) && useradmin[user['name']] != (user['privilege'] == 'admin')
   useradmin[user['name']] = (user['privilege'] == 'admin')
-  raise "Database name (#{user['database']}) is not listed in influxdb.databases" unless dbs.include? user['database'] || user['database'].nil?
+  raise "Database name (#{user['database']}) is not listed in influxdb.databases" if !dbs.include?(user['database']) && user['database'].to_s != ''
   raise "User name (#{user['name']} should match #{username_regex.inspect}" unless user['name'].match(username_regex)
   raise "User name #{admin_username} is reserved" if user['name'] == admin_username
   raise "Password for user #{user['name']} should match #{password_regex.inspect}" unless user['password'].match(password_regex)
@@ -200,6 +200,9 @@ create-or-update-user () {
 #--------------#
 #     MAIN     #
 #--------------#
+echo
+echo "=== starting influxdb setup ==="
+
 if ping-influxdb; then
   bootstrap-auth
 

--- a/manifests/influxdb.yml
+++ b/manifests/influxdb.yml
@@ -37,6 +37,9 @@ instance_groups:
           password: iftheyonlyknew
           privilege: write
           database: example
+        - name: administrator
+          password: godhelpme
+          privilege: admin
         retention_policy_rules:
           example:
             default: autogen


### PR DESCRIPTION
There was a mistake in the ruby script that would cause deploy to fail if requesting to create an admin user in the expected way (i.e. not specifying a database). This fixes the problem: the example manifest is also updated to include an administrator user.

Fix #3 