### PR TITLE
Fix user exists

### DIFF
--- a/jobs/influxdb/templates/bin/influxdb_setup.erb
+++ b/jobs/influxdb/templates/bin/influxdb_setup.erb
@@ -155,7 +155,7 @@ apply-retention-policy () {
 
 user-exists () {
   # Test if user exists in influxdb or not
-  if $INFLUX -format csv -execute 'show users' | tail -n +2 | cut -d, -f2 | grep -q "^${1}$" ; then
+  if $INFLUX -format csv -execute 'show users' | tail -n +2 | cut -d, -f1 | grep -q "^${1}$" ; then
     return 0
   else
     return 1


### PR DESCRIPTION
The formatting of the user table has changed between 1.1 and 1.4.x; as a result the function that checks whether a user already exists or not was always returning that the user did not exist - and this caused the password change functionality to stop working.

This fixes the problem and allows to update passwords again.