### PR TITLE
Restrict access to the admin password file

### DIFF
--- a/jobs/influxdb/templates/bin/influxdb_ctl.erb
+++ b/jobs/influxdb/templates/bin/influxdb_ctl.erb
@@ -19,11 +19,17 @@ exec 2> >( tee -a /var/vcap/sys/log/influxdb_ctl.err.log | logger -p user.error 
 ulimit -c unlimited
 ulimit -n <%= p("influxdb.max_open_fd") %>
 
-for DIR in $DATA_DIR $STORE_DIR $LOG_DIR $RUN_DIR; do
+for DIR in $DATA_DIR $LOG_DIR $RUN_DIR; do
   mkdir -p "$DIR"
   chown -R vcap:vcap "$DIR"
   chmod 755 "$DIR"
 done
+
+# $STORE_DIR contains the admin_password_file that must have
+# permissions 600/root:root, so avoid doing chown -R
+mkdir -p "$STORE_DIR"
+chown vcap:vcap "$STORE_DIR"
+chmod 755 "$STORE_DIR"
 
 case $1 in
   start)

--- a/jobs/influxdb/templates/bin/influxdb_setup.erb
+++ b/jobs/influxdb/templates/bin/influxdb_setup.erb
@@ -72,11 +72,11 @@ ADMIN_USERNAME="<%= admin_username %>"
 ADMIN_PASSWORD_FILE="/var/vcap/store/influxdb/admin_password_file"
 if [ ! -f "$ADMIN_PASSWORD_FILE" ]; then
   # generate the admin password and store it in /var/vcap/store
-  openssl rand -hex 16 > "$ADMIN_PASSWORD_FILE"
+  xxd -l 16 -pu </dev/urandom >"$ADMIN_PASSWORD_FILE"
 fi
-sudo chmod 0600 "$ADMIN_PASSWORD_FILE"
-sudo chown root:root "$ADMIN_PASSWORD_FILE"
-ADMIN_PASSWORD=$(sudo cat "$ADMIN_PASSWORD_FILE")
+chmod 0600 "$ADMIN_PASSWORD_FILE"
+chown root:root "$ADMIN_PASSWORD_FILE"
+ADMIN_PASSWORD=$(cat "$ADMIN_PASSWORD_FILE")
 INFLUX="influx -username $ADMIN_USERNAME -password $ADMIN_PASSWORD"
 
 ping-influxdb () {
@@ -97,7 +97,7 @@ bootstrap-auth () {
   $INFLUX -execute "SHOW USERS" 1>/dev/null 2>/dev/null && \
     echo "Admin user $ADMIN_USERNAME already exists" && \
     return 0
-  
+
   influx -execute "CREATE USER $ADMIN_USERNAME WITH PASSWORD '$ADMIN_PASSWORD' WITH ALL PRIVILEGES"
   echo "Creating admin user $ADMIN_USERNAME: $?"
 }

--- a/jobs/influxdb/templates/bin/influxdb_setup.erb
+++ b/jobs/influxdb/templates/bin/influxdb_setup.erb
@@ -71,10 +71,12 @@ INFLUXDB_HTTP_PORT=<%= p('influxdb.http.port') %>
 ADMIN_USERNAME="<%= admin_username %>"
 ADMIN_PASSWORD_FILE="/var/vcap/store/influxdb/admin_password_file"
 if [ ! -f "$ADMIN_PASSWORD_FILE" ]; then
-  # generate the admin password
+  # generate the admin password and store it in /var/vcap/store
   openssl rand -hex 16 > "$ADMIN_PASSWORD_FILE"
 fi
-ADMIN_PASSWORD=$(cat "$ADMIN_PASSWORD_FILE")
+sudo chmod 0600 "$ADMIN_PASSWORD_FILE"
+sudo chown root:root "$ADMIN_PASSWORD_FILE"
+ADMIN_PASSWORD=$(sudo cat "$ADMIN_PASSWORD_FILE")
 INFLUX="influx -username $ADMIN_USERNAME -password $ADMIN_PASSWORD"
 
 ping-influxdb () {
@@ -226,6 +228,10 @@ end.join("\n") %>
 <%= users.map do |user|
   "  create-or-update-user \"#{user['name']}\" \"#{user['password']}\" \"#{user['privilege']}\" \"#{user['database']}\""
 end.join("\n") %>
+
+  # ensure that all changes (especially the credentials for 
+  # __influxdb_admin) have been written to disk
+  sync
 
 else
   echo "Failed to setup InfluxDB... tough luck!" >&2


### PR DESCRIPTION
The admin password file was previously using the default owner/permissions of `/var/vcap/store`: `root:root` and `0644`. Given the sensitive nature of its contents, change to `root:root` and `0600`.

Also ensure that all changes have been persisted to disk at the end of the setup script (otherwise a host crash immediately after the execution of the setup script could have left the job in a broken state - e.g. if the admin_password_file hadn't been synced to disk).

Tested both upgrading from an existing deployment and creating a new deployment:
```
influxdb/e5667339-ba90-4e9c-ad86-982b1bd3ed51:~$ ls -al /var/vcap/store/influxdb/
total 24
drwxr-xr-x 5 vcap vcap 4096 Jun 20 04:20 .
drwxr-xr-x 4 root root 4096 Jun 20 04:20 ..
-rw------- 1 root root   33 Jun 20 04:20 admin_password_file
drwxr-xr-x 3 vcap vcap 4096 Jun 20 04:20 data
drwxr-xr-x 2 vcap vcap 4096 Jun 20 04:21 meta
drwx------ 3 vcap vcap 4096 Jun 20 04:20 wal
```